### PR TITLE
Fixing non-deterministic test issue in ParametersTest.shouldGetKeyValues()

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/util/ParametersTest.java
@@ -66,8 +66,13 @@ public class ParametersTest {
         parameters.set(null, "a", "axe", "b", "bat", "c", "cat");
 
         final Object[] params = parameters.getKeyValues(mock(Traverser.Admin.class));
+        Arrays.sort(params);
+
+        Object[] expected = new Object[] {"a", "axe", "b", "bat", "c", "cat"};
+        Arrays.sort(expected);
+
         assertEquals(6, params.length);
-        assertThat(Arrays.equals(new Object[] {"a", "axe", "b", "bat", "c", "cat"}, params), is(true));
+        assertThat(Arrays.equals(expected, params), is(true));
     }
 
     @Test


### PR DESCRIPTION
When running "mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldGetKeyValues -Drat.skip=true", I noticed the failure:
 
ParametersTest.shouldGetKeyValues:70 
Expected: is true
     but: was false
 
It seems to be an ID level NonDex issue when compareing params with the new object array, which means test might fail even if the objects in the two array are the same but in different order, so I used sort on both object arrays to ensure the order are the same for each comparison.